### PR TITLE
Make sure we always render parent components before children

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,11 +11,7 @@
     "./html": "./src/html.js"
   },
   "types": "./types/index.d.ts",
-  "files": [
-    "dist",
-    "src",
-    "types"
-  ],
+  "files": ["dist", "src", "types"],
   "keywords": [
     "dependable",
     "vdom",
@@ -50,7 +46,7 @@
     "node": ">=16"
   },
   "dependencies": {
-    "@dependable/state": "^0.6.2",
+    "@dependable/state": "^0.8.0",
     "htm": "^3.1.1"
   },
   "devDependencies": {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1472,4 +1472,53 @@ describe("view", () => {
       expect(renderedParent, "to be", 1);
     });
   });
+
+  describe("when a component is updated after it is unmounted", () => {
+    let oddRendered, evenRendered;
+
+    beforeEach(() => {
+      oddRendered = 0;
+      evenRendered = 0;
+      const number = observable(0);
+
+      class Even {
+        render() {
+          evenRendered++;
+          return `Even number ${number()}`;
+        }
+      }
+
+      class Odd {
+        render() {
+          oddRendered++;
+          return `Odd number ${number()}`;
+        }
+      }
+
+      class Parent {
+        willMount() {
+          number(1);
+        }
+
+        render() {
+          if (number() % 2 === 0) {
+            return html`<${Even} />`;
+          } else {
+            return html`<${Odd} />`;
+          }
+        }
+      }
+
+      render(html`<${Parent} />`, container);
+      flush();
+      number(2);
+      flush();
+    });
+
+    it("ignores the update", () => {
+      expect(container, "to satisfy", `<div>Even number 2</div>`);
+      expect(evenRendered, "to be", 1);
+      expect(oddRendered, "to be", 1);
+    });
+  });
 });


### PR DESCRIPTION
I found a major problem where depending on the same observable for a parent and a child component render the child component in an incorrect state, because it was updated before the parent component that should actually have unmounted the child component. 

This PR fixes this situation by never executing pending renders on unmounted components and ensures that parent components is always updated before their children. This is done by subscribing to observables with lower priority precedence for components deeper in the rendering tree. I also no longer use a computed to render the VDOM as that will always be updated automatically and you can't control the order of that.